### PR TITLE
Fixing tiny typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ further details.
 
 ### `jp-coffee-install`: jp-CoffeeScript kernel spec installer
 
-'jp-coffee-install` registers the jp-CoffeeScript kernel with Jupyter, so that
+`jp-coffee-install` registers the jp-CoffeeScript kernel with Jupyter, so that
 other tools (e.g. the Jupyter notebook) can invoke it. The following command
 flags are recognised:
 


### PR DESCRIPTION
There was just one backwards tick mark that caused a piece of `code` to not be rendered as such.  Fixed one single character.